### PR TITLE
Add more docs and make LLVM support optional

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+https://codecaptured.com/contact/.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to The Force
+
+Thank you for helping out with the The Force!
+
+Following these guidelines helps us keep good project workflow. We appreciate you working with us on it. 
+
+Please read our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) to understand our community expectations.
+
+## How to help?
+
+Please check the [Issues][Issues] for current task. If you see something that you would like to help with, ask about helping in a comment and we'll assign it too you.
+
+Checkout the [DESIGN.md](DESIGN.md) file for a high level explanation of the project.
+
+### Report Bug 
+
+Check to see if someone already reported this [bug][Bug Issues] already exists. If so then leave a comment on that issue. If not, please provide a detailed description of the bug. Include what was happening before the error, all settings, and test results. This helps us more quickly identify and solve any problems. Create an [Issue][Issues] with the description and add a bug label. We will do our best to respond quickly to it. 
+
+### Request a Feature
+
+Check to see if the feature is already listed in our [feature requests][Feature Issues]. If it's not, describe the feature and why it would be beneficial. Create an [Issue][Issues] with this description and add a feature enhancement label. We will do our best to respond quickly to it. 
+
+### Submit Example Code
+
+If you have a program written in The Force that you'd like to share, please do! Make a Pull Request to add it to the Examples folder.
+
+### Work on The Force
+
+If you'd like to fix bugs or add features to The Force, please submit an issue or comment on a relevant issue to share your intentions and ask any questions. 
+
+Once you are ready to make the Pull Request, consult the [Pull Request Checklist](#Pull-Request-Checklist)
+
+## Pull Request Checklist
+
+Please do these things before you make your Pull Request
+
+- [ ] Add any relevant unit tests
+- [ ] Make sure all unit tests pass with `cargo test`
+- [ ] Use our [.editorconfig](.editorconfig) to help automatically style all files
+- [ ] Format the code with `cargo fmt`
+
+[Issues]: https://github.com/mirdaki/theforce/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
+[Bug Issues]: https://github.com/mirdaki/theforce/labels/bug
+[Feature Issues]: https://github.com/mirdaki/theforce/labels/enhancement

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ Please do these things before you make your Pull Request
 - [ ] Make sure all unit tests pass with `cargo test`
 - [ ] Use our [.editorconfig](.editorconfig) to help automatically style all files
 - [ ] Format the code with `cargo fmt`
+- [ ] Link the relevant issue the Pull Request addresses
 
 [Issues]: https://github.com/mirdaki/theforce/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
 [Bug Issues]: https://github.com/mirdaki/theforce/labels/bug

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,10 @@ name = "theforce"
 version = "0.1.0"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+llvm = ["inkwell"]
 
 [dependencies]
-inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "llvm10-0" }
+inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "llvm10-0", optional = true }
 pest = "2.1.3"
 pest_derive = "2.1.0"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
 # The Force
 
-The Force is a gateway to abilities many believe are unnatural
+> The Force is a gateway to abilities many believe are unnatural...
+
+## Getting Started
+
+Install Rust. We also provide a [Dev Container](https://code.visualstudio.com/docs/remote/create-dev-container) if you would prefer to run it that way.
+
+To run the examples:
+```bash
+cargo run < examples/hello-there.force
+```
+
+To run with LLVM support (currently a WIP):
+```bash
+cargo run --features llvm < examples/hello-there.force
+```
+
+## Built With
+
+Thank you to all the projects that helped make this possible!
+
+- [Rust](https://www.rust-lang.org/) for being an awesome language to build with
+- [Pest](https://pest.rs/) used for defining and parsing the grammar
+- [Create Your Own Programming Language with Rust](https://createlang.rs/) provided an excellent introduction into the Rust tools needed to build this
+- [ArnoldC](https://lhartikk.github.io/ArnoldC/) for providing inspiration for the design
+
+## Contributing
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for how to contribute to the project.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.
+
+The Force is in no way affiliated with or endorsed by Lucasfilm Limited or any of its subsidiaries, employees, or associates. All Star Wars quotes and references in this project are copyrighted to Lucasfilm Limited. This project intends to use these strictly within the terms of fair use under United States copyright laws.
+
+<small>Disney please don't sue us.</small>

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
 use std::io::{self, Read};
 
 mod ast;
-mod compiler;
 mod interpreter;
 mod parser;
+
+#[cfg(feature = "llvm")]
+mod compiler;
 
 fn main() -> Result<(), String> {
     let mut buffer = String::new();


### PR DESCRIPTION
Adds more information to the README #2, and other supporting documents, such as the Code of Conduct and Contributing file.

Also make the LLVM support optional. Especially useful as it doesn't work right now