### PR TITLE
Separate parse errors if requested

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,13 @@ pub fn parse_arguments() -> ArgMatches<'static> {
                 .required(true)
                 .index(1),
         )
+        .arg(
+            Arg::with_name("parse_error")
+            .long("ERROR_AFTER_PARSE")
+            .help("Indicates to error before execution if specified.")
+            .required(false)
+            .index(2),
+        )
         .get_matches()
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,13 +18,6 @@ pub fn parse_arguments() -> ArgMatches<'static> {
                 .required(true)
                 .index(1),
         )
-        .arg(
-            Arg::with_name("parse_error")
-            .long("ERROR_AFTER_PARSE")
-            .help("Indicates to error before execution if specified.")
-            .required(false)
-            .index(2),
-        )
         .get_matches()
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,5 +13,14 @@ fn main() -> Result<(), String> {
     let source = cli::read_source(args)?;
 
     let ast = parser::parse(source.as_str());
-    interpreter::evaluate(ast.unwrap(), io::stdin().lock(), io::stdout())
+
+    if args.contains_id("parse_error") {
+        match ast {
+            Ok(t) => interpreter::evaluate(t, io::stdin().lock(), io::stdout()),
+            Err(e) => Err(format!("Error encountered while parsing: {}", e).to_string()),
+        }
+    }
+    else {
+        interpreter::evaluate(ast.unwrap(), io::stdin().lock(), io::stdout())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,13 +14,8 @@ fn main() -> Result<(), String> {
 
     let ast = parser::parse(source.as_str());
 
-    if args.contains_id("parse_error") {
-        match ast {
-            Ok(t) => interpreter::evaluate(t, io::stdin().lock(), io::stdout()),
-            Err(e) => Err(format!("Error encountered while parsing: {}", e).to_string()),
-        }
-    }
-    else {
-        interpreter::evaluate(ast.unwrap(), io::stdin().lock(), io::stdout())
+    match ast {
+        Ok(t) => interpreter::evaluate(t, io::stdin().lock(), io::stdout()),
+        Err(e) => Err(format!("Error encountered while parsing: {}", e).to_string()),
     }
 }


### PR DESCRIPTION
I'm not convinced we should have a separate CLI argument for this...why would you not want it?