### PR TITLE
Roman numerals

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -20,7 +20,7 @@ The Force supports these programing language constructs:
 - Noop
 
 The Force supports three types:
-- Floats (1 - 9 can alternatively be represented by roman numerals: I, II, III, IV, V, VI, VII, VIII, IX)
+- Floats (1 - 9 can alternatively be represented by roman numerals: `I`, `II`, `III`, `IV`, `V`, `VI`, `VII`, `VIII`, `IX`)
 - Booleans (which are represented as Star Wars quotes instead of `True` or `False`)
 - Strings
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -20,7 +20,7 @@ The Force supports these programing language constructs:
 - Noop
 
 The Force supports three types:
-- Floats
+- Floats (1 - 9 can alternatively be represented by roman numerals: I, II, III, IV, V, VI, VII, VIII, IX)
 - Booleans (which are represented as Star Wars quotes instead of `True` or `False`)
 - Strings
 

--- a/examples/episodes.force
+++ b/examples/episodes.force
@@ -1,0 +1,28 @@
+Do it!
+    Size matters not. porg
+    Who, mesa? 0.0
+
+    What a piece of junk! porg
+        I am your father. porg
+        Your lightsabers will make a fine addition to my collection. IV
+        Your lightsabers will make a fine addition to my collection. V
+        Your lightsabers will make a fine addition to my collection. VI
+        Not to worry, we are still flying half a ship. III
+        Proceed with the countdown. V
+        Your lightsabers will make a fine addition to my collection. I
+        Your lightsabers will make a fine addition to my collection. II
+        Your lightsabers will make a fine addition to my collection. III
+        Not to worry, we are still flying half a ship. III
+        Proceed with the countdown. II
+        Your lightsabers will make a fine addition to my collection. VII
+        Your lightsabers will make a fine addition to my collection. VIII
+        Your lightsabers will make a fine addition to my collection. IX
+        Not to worry, we are still flying half a ship. III
+        Proceed with the countdown. VIII
+        Your lightsabers will make a fine addition to my collection. I
+        There's too many of them! III
+    The garbage will do.
+
+    The Sacred Jedi Texts! porg
+    The Sacred Jedi Texts! "\n"
+May The Force be with you.

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -152,7 +152,9 @@ FunctionName = { Identifier }
 
 Identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC)* }
 
-Float = @{ "-"? ~ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? }
+NormalFloat = @{ "-"? ~ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? }
+EpisodeFloat = @{ "IX" | "VIII" | "VII" | "VI" | "V" | "IV" | "III" | "II" | "I" }
+Float = { NormalFloat | EpisodeFloat }
 
 Boolean = { True | False }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -394,6 +394,12 @@ mod tests {
                 Not to worry, we are still flying half a ship. 5
                 Unlimited power! 2
                 Never tell me the odds! 10
+                Your lightsabers will make a fine addition to my collection. V
+                Proceed with the countdown. II
+                There's too many of them! IX
+                Not to worry, we are still flying half a ship. IV
+                Unlimited power! III
+                Never tell me the odds! I
             The garbage will do.
 
             The Sacred Jedi Texts! porg
@@ -416,6 +422,12 @@ mod tests {
                         Node::Binary(BinaryOperation::Divide, Box::new(Node::Float(5.0))),
                         Node::Binary(BinaryOperation::Exponent, Box::new(Node::Float(2.0))),
                         Node::Binary(BinaryOperation::Modulus, Box::new(Node::Float(10.0))),
+                        Node::Binary(BinaryOperation::Add, Box::new(Node::Float(5.0))),
+                        Node::Binary(BinaryOperation::Subtract, Box::new(Node::Float(2.0))),
+                        Node::Binary(BinaryOperation::Multiply, Box::new(Node::Float(9.0))),
+                        Node::Binary(BinaryOperation::Divide, Box::new(Node::Float(4.0))),
+                        Node::Binary(BinaryOperation::Exponent, Box::new(Node::Float(3.0))),
+                        Node::Binary(BinaryOperation::Modulus, Box::new(Node::Float(1.0))),
                     )
                 ),
                 Node::Print(Box::new(Node::Variable("porg".to_string()))),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -221,7 +221,19 @@ fn build_ast(pair: pest::iterators::Pair<Rule>) -> Node {
         }
         Rule::Float => {
             let float = pair.as_str();
-            let float = float.parse::<f32>().unwrap();
+            let float = match float {
+                "IX" => 9.0,
+                "VIII" => 8.0,
+                "VII" => 7.0,
+                "VI" => 6.0,
+                "V" => 5.0,
+                "IV" => 4.0,
+                "III" => 3.0,
+                "II" => 2.0,
+                "I" => 1.0,
+                _ => float.parse::<f32>().unwrap(),
+            };
+
             Node::Float(float)
         }
         Rule::String => {


### PR DESCRIPTION
This resolves issue #44 and relates to issue #35

- Roman numerals for all 9 episodes have been added
- They get mapped to floats when building the AST
- Math test expanded to include them
- Example file added to use them

If we want full Roman numeral support then let me know, I'd be happy to expand on this!
For now I thought this would be a good start.